### PR TITLE
Management more sheet

### DIFF
--- a/django_jsheet/src/core/views.py
+++ b/django_jsheet/src/core/views.py
@@ -109,7 +109,7 @@ class DjangoSheetFormView(FormView):
             return False, ex
 
         data = []
-        for i, row in data_row.items():
+        for row in data_row.values():
             data.append(row)
 
         try:

--- a/django_jsheet/src/core/views.py
+++ b/django_jsheet/src/core/views.py
@@ -133,20 +133,19 @@ class DjangoSheetFormView(FormView):
                 self.header.extend(["" for _ in range(nr_base_fields - nr_header)])
 
     def mk_jspath(self) -> str:
-        jspath = str(self.LOGROOT) + "/jsheet/js/"
-        if not os.path.exists(jspath):
-            os.makedirs(jspath)
+        jspath = f"{self.LOGROOT}/jsheet/js/{self.DIR_DATA}"
+        os.makedirs(jspath, exist_ok=True)
         return jspath
 
     def mk_file_log(self) -> (str, str):
         path_logs = str(self.LOGROOT) + "/jsheet/"
-        if not os.path.exists(path_logs):
-            os.makedirs(path_logs)
+        os.makedirs(path_logs, exist_ok=True)
 
         if self.SVIL:
             now_ = datetime.now().strftime("%d%m%Y")
         else:
             now_ = datetime.now().strftime("%d%m%Y_%H%M%S")
+
         # init filelog
         filelog = path_logs + "datalog_" + now_ + ".log"
         return path_logs, filelog
@@ -277,19 +276,19 @@ class DjangoSheetFormView(FormView):
             header.append(type_header)
 
         datajs += str(header).replace('"', "").replace(",,", ",") + "})"
-        jsfile = self.jspath + "/header.js"
+        jsfile = os.path.join(self.jspath, "..", "header.js")
         with open(jsfile, "w") as fl:
             fl.write(datajs)
 
     def make_fetch_js(self):
         # get current url and relative path url
         current_url = self.request.resolver_match.view_name
-        post_url = reverse_lazy(current_url)
+        post_url = reverse_lazy(current_url, kwargs={'sheet': self.filename})
 
         # make fetch post JS
         fetch_post = get_fetch_js() % (self.TIME_UPDATE, post_url)
 
         # make and put scripts in fetch_post.js in jspath dir
-        jsfile = self.jspath + "/fetch_post.js"
+        jsfile = os.path.join(self.jspath, "..", "fetch_post.js")
         with open(jsfile, "w") as fl:
             fl.write(fetch_post)

--- a/django_jsheet/src/core/views.py
+++ b/django_jsheet/src/core/views.py
@@ -182,8 +182,9 @@ class DjangoSheetFormView(FormView):
         else:
             datajs += str(data) + ";"
 
-        with open(self.jsdata, "w") as fl:
-            fl.write(datajs)
+        if not self.jsdata.split("/")[-1] == 'None.js':
+            with open(self.jsdata, "w") as fl:
+                fl.write(datajs)
 
     def prepopulate_datajs(self):
         datajs = ""

--- a/django_jsheet/src/templatetags/jspread_import.py
+++ b/django_jsheet/src/templatetags/jspread_import.py
@@ -1,0 +1,39 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def display_bottom_sheet(sheets: str, url_name: str, style_cl: str = None, style_id: str = None):
+    if style_cl is None:
+        style_cl = ""
+    if style_id is None:
+        style_id = ""
+
+    sheets = sheets.split(",")
+    html = []
+    for name in sheets:
+        _button = f"""
+<input type='button' onclick='location.href="/{url_name}/{name}/";'
+value='{name}' class='{style_cl}' id='{style_id}' />
+        """
+        html.append(_button)
+    return mark_safe("".join(html))
+
+
+@register.simple_tag
+def display_jsheet(folder: str = None, filename: str = None, domain: str = None):
+    if not folder:
+        folder = "data"
+    if not filename:
+        filename = "data_1"
+    if not domain:
+        domain = ""
+
+    data_links = f"""
+<script src="{domain}/media/jsheet/js/{folder}/{filename}.js"></script>
+<script src="{domain}/media/jsheet/js/header.js"></script>
+<script src="{domain}/media/jsheet/js/fetch_post.js"></script>
+    """
+    return mark_safe(data_links.strip())


### PR DESCRIPTION
Moved all the request.method.POST directly inside the POST method (as it should be .-.)

Added:
- DIR_DATA to choose the directory name, where we will put all the data files of the various tabs
- in the self param filename that determines the name of the tab and comes directly from the url and contained in the kwargs with the key 'sheet'
- the method get_context_data() with the keys:
    - FOLDER calling > DIR_DATA
    - FILENAME which calls > filename
    - SHEETS which calls > all filenames
- the templatetags jspread_import to create:
    - the buttons to change the selected tab
    - scripts links:
        - "data_x.js" > contains the data of the tab
        - "header.js" > defines the columns
        - "fetch_post.js" > allows data to be sent

Quick fixes and generic reformat